### PR TITLE
Specify model name in deploy instruction

### DIFF
--- a/pet-object-detection/README.md
+++ b/pet-object-detection/README.md
@@ -9,9 +9,9 @@ for a cat or dog using a YOLOv8 model. If a pet is detected in any participants 
 You can deploy the example below in just a few easy steps.
 1. Git Clone the repository and make sure you are in the pet-object-detection folder
 2. Sign up at https://dashboard.cerebrium.ai since we will need to get our API keys to deploy this example.
-3. Run the following command in your terminal: `pip install --upgrade cerebrium``.
-4. Run the following command in your terminal: `cerebrium login <private_api_key>``. The private-api_key can be found on your Cerebrium dashboard.
-5. Run the command cerebrium deploy --config-file ./config.yaml
+3. Run the following command in your terminal: `pip install --upgrade cerebrium`.
+4. Run the following command in your terminal: `cerebrium login <private_api_key>`. The private-api_key can be found on your Cerebrium dashboard.
+5. Run the command `cerebrium deploy --config-file ./config.yaml petdetection`
 6. Your deployment will take about a minute or 2 since we are setting up your environment. Don't worry, subsequent deployments will be much faster if you make changes:)
 
 Congrats your deployment should be live and you should see it live in your dashboard. You then should see a Curl Request in your terminal or example requests in your dashboard which we will use in the steps below to call our implementation.


### PR DESCRIPTION
I initially ran into an error when running the deploy command:

<img width="705" alt="image" src="https://github.com/CerebriumAI/daily-demos/assets/65890040/a9d2e509-9b43-4e6e-aaf9-a7a6923a7516">

After adding a model name (last line in screenshot above) it worked, so this PR just suggests adding a name to the example.

Related, the original name I used utilized upper case letters (`PetDetection`), and the resulting output in the build/run URLs reflected the same capitalization as follows:

<img width="710" alt="Screenshot 2023-10-02 at 17 58 36" src="https://github.com/CerebriumAI/daily-demos/assets/65890040/97a09599-60b0-416c-ae5d-a99b9adcebf2">

However, URLs above could not be followed as the model ID was not found. Looks like the model name was converted to lower-case letters at some point during deployment, so the actual URL should have included `petdetection` as the name vs the original `PetDetection`. (To avoid confusion in the meantime I made the README change below use a lower-case name)

Really awesome demo!!